### PR TITLE
Boulangerie::Type

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,12 @@ LineLength:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
+Style/ClassVars:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
 Metrics/MethodLength:
   CountComments: false
   Max: 25

--- a/lib/boulangerie.rb
+++ b/lib/boulangerie.rb
@@ -1,15 +1,24 @@
+# stdlib stuff
 require "securerandom"
 require "yaml"
 
+# External gems
 require "rbnacl/libsodium"
 require "macaroons"
 
 require "boulangerie/version"
 
+# Boulangerie Classes
 require "boulangerie/identifier"
 require "boulangerie/keyring"
 require "boulangerie/predicate"
 require "boulangerie/schema"
+require "boulangerie/type"
+
+# Boulangerie Types
+require "boulangerie/type/binary"
+require "boulangerie/type/boolean"
+require "boulangerie/type/date_time"
 
 # An opinionated library for creating and verifying Macaroons in Ruby
 class Boulangerie
@@ -20,6 +29,9 @@ class Boulangerie
 
   # Caveats are invalid
   InvalidCaveatError = Class.new(StandardError)
+
+  # Problems with serialization/deserialization
+  SerializationError = Class.new(StandardError)
 
   # Default Boulangerie
   @default = nil
@@ -80,7 +92,7 @@ class Boulangerie
         predicate = @schema.predicates[id]
         fail InvalidCaveatError, "no predicate in schema for: #{id.inspect}" unless predicate
 
-        macaroon.add_first_party_caveat(id + " " + predicate.serialize(caveat))
+        macaroon.add_first_party_caveat("#{id} #{predicate.serialize(caveat)}")
       end
     end
   end

--- a/lib/boulangerie/predicate.rb
+++ b/lib/boulangerie/predicate.rb
@@ -3,25 +3,19 @@ class Boulangerie
   class Predicate
     attr_reader :type
 
-    # Built-in types supported by Boulangerie
-    BUILT_IN_TYPES = %w(
-      DateTime
-      Binary
-      String
-      Boolean
-    )
-
     def initialize(options)
       case options
-      when String then @type = options.freeze
+      when String then @type = Type[options]
       else fail TypeError, "invalid predicate: #{options.inspect} (expecting String)"
       end
-
-      fail TypeError, "bad predicate type: #{@type.inspect}" unless BUILT_IN_TYPES.include?(@type)
     end
 
     def serialize(value)
-      value.to_s
+      unless @type.allowed_classes.any? { |klass| value.is_a?(klass) }
+        fail TypeError, "can't serialize #{value.class} as a #{@type.type_name}"
+      end
+
+      @type.serialize(value)
     end
   end
 end

--- a/lib/boulangerie/type.rb
+++ b/lib/boulangerie/type.rb
@@ -1,0 +1,25 @@
+class Boulangerie
+  # Static types for schemas and serialized data
+  class Type
+    @@types = {}
+
+    attr_accessor :type_name
+    attr_reader :allowed_classes
+
+    def self.register(type_name, obj)
+      fail ArgumentError, "duplicate type name: #{type_name}" if @@types.key?(type_name)
+      fail TypeError, "#{obj} not a #{self} subclass" unless obj.is_a?(self)
+
+      obj.type_name = type_name
+      @@types[type_name.freeze] = obj.freeze
+    end
+
+    def self.[](type_name)
+      @@types[type_name] || fail(TypeError, "invalid Boulangerie::Type: #{type_name.inspect}")
+    end
+
+    def initialize(allowed_classes: [])
+      @allowed_classes = Array(allowed_classes)
+    end
+  end
+end

--- a/lib/boulangerie/type/binary.rb
+++ b/lib/boulangerie/type/binary.rb
@@ -1,0 +1,20 @@
+# Support for opaque binary data
+class Boulangerie::Type::Binary < Boulangerie::Type
+  register "Binary", new(allowed_classes: String)
+
+  def serialize(string)
+    unless string.encoding == Encoding::BINARY
+      fail Boulangerie::SerializationError, "bad string encoding: #{string.encoding}"
+    end
+
+    string
+  end
+
+  def deserialize(string)
+    unless string.encoding == Encoding::BINARY
+      fail Boulangerie::SerializationError, "bad string encoding: #{string.encoding}"
+    end
+
+    string
+  end
+end

--- a/lib/boulangerie/type/boolean.rb
+++ b/lib/boulangerie/type/boolean.rb
@@ -1,0 +1,16 @@
+# Support for 'true' and 'false'
+class Boulangerie::Type::Boolean < Boulangerie::Type
+  register "Boolean", new(allowed_classes: [TrueClass, FalseClass, NilClass])
+
+  def serialize(value)
+    value == true ? "true".freeze : "false".freeze
+  end
+
+  def deserialize(string)
+    case string
+    when "true".freeze  then true
+    when "false".freeze then false
+    else fail Boulangerie::SerializationError, "expecting Boolean value: #{string.inspect}"
+    end
+  end
+end

--- a/lib/boulangerie/type/date_time.rb
+++ b/lib/boulangerie/type/date_time.rb
@@ -1,0 +1,14 @@
+require "time"
+
+# Support for ISO8601 dates
+class Boulangerie::Type::DateTime < Boulangerie::Type
+  register "DateTime", new(allowed_classes: Time)
+
+  def serialize(datetime)
+    datetime.iso8601
+  end
+
+  def deserialize(string)
+    Time.iso8601(string)
+  end
+end

--- a/spec/boulangerie/type/binary_spec.rb
+++ b/spec/boulangerie/type/binary_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe Boulangerie::Type::Binary do
+  let(:example_string) { "AAAAAAAA".force_encoding("BINARY") }
+
+  describe "#serialize" do
+    it "serializes BINARY strings" do
+      expect(subject.serialize(example_string)).to eq example_string
+    end
+
+    it "raises SerializationError on non-BINARY strings" do
+      expect do
+        subject.serialize(example_string.force_encoding("UTF-8"))
+      end.to raise_error(Boulangerie::SerializationError)
+    end
+  end
+
+  describe "#deserialize" do
+    it "deserializes" do
+      expect(subject.deserialize(example_string)).to eq example_string
+    end
+
+    it "raises SerializationError on non-BINARY strings" do
+      expect do
+        subject.deserialize(example_string.force_encoding("UTF-8"))
+      end.to raise_error(Boulangerie::SerializationError)
+    end
+  end
+end

--- a/spec/boulangerie/type/boolean_spec.rb
+++ b/spec/boulangerie/type/boolean_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe Boulangerie::Type::Boolean do
+  describe "#serialize" do
+    it "serializes TrueClass" do
+      expect(subject.serialize(true)).to eq "true"
+    end
+
+    it "serializes FalseClass" do
+      expect(subject.serialize(false)).to eq "false"
+    end
+
+    it "serializes NilClass" do
+      expect(subject.serialize(nil)).to eq "false"
+    end
+  end
+
+  describe "#deserialize" do
+    it "deserializes 'true'" do
+      expect(subject.deserialize("true")).to eq true
+    end
+
+    it "deserializes 'false'" do
+      expect(subject.deserialize("false")).to eq false
+    end
+
+    it "raises SerializationError on other strings" do
+      expect { subject.deserialize("truthy") }.to raise_error(Boulangerie::SerializationError)
+    end
+  end
+end

--- a/spec/boulangerie/type/date_time_spec.rb
+++ b/spec/boulangerie/type/date_time_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Boulangerie::Type::DateTime do
+  let(:example_time) { Time.at(Time.now.to_i) }
+
+  describe "#serialize" do
+    it "serializes Time objects" do
+      serialized = subject.serialize(example_time)
+      expect(Time.iso8601(serialized)).to eq example_time
+    end
+  end
+
+  describe "#deserialize" do
+    it "deserializes" do
+      deserialized_time = subject.deserialize(example_time.iso8601)
+      expect(deserialized_time).to eq example_time
+    end
+  end
+end

--- a/spec/fixtures/badly_versioned_schema.yml
+++ b/spec/fixtures/badly_versioned_schema.yml
@@ -5,8 +5,6 @@ predicates:
     time-before: DateTime
     time-after: DateTime
     blobby: Binary
-    stringy: String
     booleany: Boolean
   v2:
-    another-stringy: String
     another-booleany: Boolean

--- a/spec/fixtures/duplicate_predicate_schema.yml
+++ b/spec/fixtures/duplicate_predicate_schema.yml
@@ -5,8 +5,6 @@ predicates:
     time-before: DateTime
     time-after: DateTime
     blobby: Binary
-    stringy: String
     booleany: Boolean
   v1:
-    stringy: String
-    another-booleany: Boolean
+    booleany: Boolean

--- a/spec/fixtures/example_schema.yml
+++ b/spec/fixtures/example_schema.yml
@@ -5,8 +5,6 @@ predicates:
     time-before: DateTime
     time-after: DateTime
     blobby: Binary
-    stringy: String
     booleany: Boolean
   v1:
-    another-stringy: String
     another-booleany: Boolean

--- a/spec/fixtures/invalid_keys_schema.yml
+++ b/spec/fixtures/invalid_keys_schema.yml
@@ -5,9 +5,7 @@ predicates:
     time-before: DateTime
     time-after: DateTime
     blobby: Binary
-    stringy: String
     booleany: Boolean
   v1:
-    another-stringy: String
     another-booleany: Boolean
 randomgarbage: Cool!

--- a/spec/fixtures/unidentified_schema.yml
+++ b/spec/fixtures/unidentified_schema.yml
@@ -4,5 +4,4 @@ predicates:
     time-before: DateTime
     time-after: DateTime
     blobby: Binary
-    stringy: String
     booleany: Boolean


### PR DESCRIPTION
Adds a class for representing types in schemas. Types must respond to `#serialize` and `#deserialize`

Implements the following types as built-ins:
* Boolean
* Binary
* DateTime