### PR TITLE
List types

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,9 +7,6 @@ LineLength:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
-Style/ClassVars:
-  Enabled: false
-
 Style/ClassAndModuleChildren:
   Enabled: false
 

--- a/lib/boulangerie.rb
+++ b/lib/boulangerie.rb
@@ -17,6 +17,8 @@ require "boulangerie/schema"
 require "boulangerie/type"
 
 # Boulangerie Types
+require "boulangerie/type/list"
+
 require "boulangerie/type/binary"
 require "boulangerie/type/boolean"
 require "boulangerie/type/date_time"

--- a/lib/boulangerie/type.rb
+++ b/lib/boulangerie/type.rb
@@ -1,21 +1,23 @@
 class Boulangerie
   # Static types for schemas and serialized data
   class Type
-    @@types = {}
+    REGISTRY = {}
 
     attr_accessor :type_name
     attr_reader :allowed_classes
 
-    def self.register(type_name, obj)
-      fail ArgumentError, "duplicate type name: #{type_name}" if @@types.key?(type_name)
+    def self.register(type_name, obj, list_allowed: false)
+      fail ArgumentError, "duplicate type name: #{type_name}" if REGISTRY.key?(type_name)
       fail TypeError, "#{obj} not a #{self} subclass" unless obj.is_a?(self)
 
       obj.type_name = type_name
-      @@types[type_name.freeze] = obj.freeze
+      REGISTRY[type_name.freeze] = obj.freeze
+
+      List.register "List(#{type_name})", List.new(list_type: obj) if list_allowed
     end
 
     def self.[](type_name)
-      @@types[type_name] || fail(TypeError, "invalid Boulangerie::Type: #{type_name.inspect}")
+      REGISTRY[type_name] || fail(TypeError, "invalid Boulangerie::Type: #{type_name.inspect}")
     end
 
     def initialize(allowed_classes: [])

--- a/lib/boulangerie/type/boolean.rb
+++ b/lib/boulangerie/type/boolean.rb
@@ -1,6 +1,6 @@
 # Support for 'true' and 'false'
 class Boulangerie::Type::Boolean < Boulangerie::Type
-  register "Boolean", new(allowed_classes: [TrueClass, FalseClass, NilClass])
+  register "Boolean", new(allowed_classes: [TrueClass, FalseClass, NilClass]), list_allowed: true
 
   def serialize(value)
     value == true ? "true".freeze : "false".freeze
@@ -10,7 +10,7 @@ class Boulangerie::Type::Boolean < Boulangerie::Type
     case string
     when "true".freeze  then true
     when "false".freeze then false
-    else fail Boulangerie::SerializationError, "expecting Boolean value: #{string.inspect}"
+    else fail Boulangerie::SerializationError, "expecting true/false value: #{string.inspect}"
     end
   end
 end

--- a/lib/boulangerie/type/date_time.rb
+++ b/lib/boulangerie/type/date_time.rb
@@ -1,6 +1,6 @@
 # Support for ISO8601 dates
 class Boulangerie::Type::DateTime < Boulangerie::Type
-  register "DateTime", new(allowed_classes: Time)
+  register "DateTime", new(allowed_classes: Time), list_allowed: true
 
   def serialize(datetime)
     datetime.utc.iso8601

--- a/lib/boulangerie/type/list.rb
+++ b/lib/boulangerie/type/list.rb
@@ -1,0 +1,19 @@
+# Support for lists of other types
+class Boulangerie::Type::List < Boulangerie::Type
+  # Character to use for delimiting elements of a list
+  DELIMITER = " "
+
+  def initialize(allowed_classes: [Array], list_type: nil)
+    super(allowed_classes: allowed_classes)
+
+    @list_type = list_type
+  end
+
+  def serialize(array)
+    array.map { |value| @list_type.serialize(value) }.join(DELIMITER)
+  end
+
+  def deserialize(string)
+    string.split(DELIMITER).map { |element| @list_type.deserialize(element) }
+  end
+end

--- a/spec/boulangerie/type/list_spec.rb
+++ b/spec/boulangerie/type/list_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Boulangerie::Type::List do
+  let(:example_type)   { "Boolean" }
+  let(:example_array)  { [true, false, true] }
+  let(:example_output) { "true false true" }
+
+  subject { described_class.new(list_type: Boulangerie::Type[example_type]) }
+
+  describe "#serialize" do
+    it "serializes" do
+      expect(subject.serialize(example_array)).to eq example_output
+    end
+  end
+
+  describe "#deserialize" do
+    it "deserializes" do
+      expect(subject.deserialize(example_output)).to eq example_array
+    end
+  end
+end

--- a/spec/fixtures/example_schema.yml
+++ b/spec/fixtures/example_schema.yml
@@ -6,5 +6,7 @@ predicates:
     time-after: DateTime
     blobby: Binary
     booleany: Boolean
+    boolean-list: List(Boolean)
+    datetime-list: List(DateTime)
   v1:
     another-booleany: Boolean


### PR DESCRIPTION
Implements generic support for non-nestable lists, with space-delimited elements

Types can elect to support lists at the time they are registered. Not all types
support lists (e.g. Binary)

Implements list support for:
* Boolean
* Datetime

Lists will be more useful with future type additions (e.g. Decimal, Label)