### PR TITLE
Remove location from the public API

### DIFF
--- a/lib/boulangerie/macaroon.rb
+++ b/lib/boulangerie/macaroon.rb
@@ -5,7 +5,9 @@ class Boulangerie
 
     attr_reader :identifier, :raw_macaroon
 
-    def_delegators :@raw_macaroon, :location, :signature, :serialize
+    # NOTE: location is intentionally not exposed as it's malleable and
+    # could lead to potential attacks if used in an authorization decision
+    def_delegators :@raw_macaroon, :signature, :serialize
 
     def self.from_binary(serialized)
       raw_macaroon = Macaroons::RawMacaroon.from_binary(serialized: serialized)

--- a/spec/boulangerie_spec.rb
+++ b/spec/boulangerie_spec.rb
@@ -46,9 +46,7 @@ RSpec.describe Boulangerie do
     it "creates Boulangerie::Macaroons" do
       Timecop.freeze do
         macaroon = boulangerie.create_macaroon(caveats: example_caveats)
-
         expect(macaroon).to be_a Boulangerie::Macaroon
-        expect(macaroon.location).to eq example_location
       end
     end
 
@@ -77,9 +75,7 @@ RSpec.describe Boulangerie do
 
     it "parses and verifies tokens" do
       macaroon = boulangerie.parse_and_verify(example_token)
-
       expect(macaroon).to be_a Boulangerie::Macaroon
-      expect(macaroon.location).to eq example_location
     end
   end
 end


### PR DESCRIPTION
The location field is specifically called out as being malleable in the format. I think this is a mistake (or at the very least an unnecessarily sharp edge), and can lead to potential attacks.

libmacaroons does not expose this in its public API and I think that makes sense. This follows suit and removes it from Boulangerie::Macaroon.
